### PR TITLE
Update DebugWorkflowDefinitionsCommand.php

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/Command/DebugWorkflowDefinitionsCommand.php
+++ b/src/Oro/Bundle/WorkflowBundle/Command/DebugWorkflowDefinitionsCommand.php
@@ -62,13 +62,13 @@ that are registered in the application.
 
   <info>php %command.full_name%</info>
 
-Use <info>--workflow-name</info> option to display the definition of a specific workflow:
+Use <info>workflow-name</info> argument to display the definition of a specific workflow:
 
-  <info>php %command.full_name% --workflow-name=<workflow-name></info>
+  <info>php %command.full_name% <workflow-name></info>
 
 HELP
             )
-            ->addUsage('--workflow-name=<workflow-name>');
+            ->addUsage(' <workflow-name>');
     }
 
     /** @noinspection PhpMissingParentCallCommonInspection */


### PR DESCRIPTION
Fix wrong help block for oro:debug:workflow:definitions command
At the moment it suggests to use option --workflow-name to show definition details but it should be an argument.
```shell 
Help:
  The oro:debug:workflow:definitions command displays workflow definitions
  that are registered in the application.
  
    php bin/console oro:debug:workflow:definitions
  
  Use --workflow-name option to display the definition of a specific workflow:
  
    php bin/console oro:debug:workflow:definitions --workflow-name=<workflow-name>
```